### PR TITLE
Dynamically discover TUNDEV via scutil

### DIFF
--- a/vpn.sh
+++ b/vpn.sh
@@ -73,7 +73,7 @@ then
     export TUNDEV=$(scutil --dns |grep if_index |grep tun |awk {'print $NF'} |tr -d '()')
     if [ -z "$TUNDEV" ]
     then
-        print "Could not dynamically discover TUNDEV; defaulting to utun0"
+        echo "Could not dynamically discover TUNDEV; defaulting to utun0"
 	    export TUNDEV="utun0"
     fi
 	killall openconnect

--- a/vpn.sh
+++ b/vpn.sh
@@ -70,7 +70,12 @@ fi
 
 if [ "$COMMAND" == "D" ]
 then
-	export TUNDEV="tun0"
+    export TUNDEV=$(scutil --dns |grep tun |awk {'print $NF'} |tr -d '()')
+    if [ -z "$TUNDEV" ]
+    then
+        print "Could not dynamically discover TUNDEV; defaulting to utun0"
+	    export TUNDEV="utun0"
+    fi
 	killall openconnect
 	scutil >/dev/null 2>&1 <<-EOF
 		open

--- a/vpn.sh
+++ b/vpn.sh
@@ -70,7 +70,7 @@ fi
 
 if [ "$COMMAND" == "D" ]
 then
-    export TUNDEV=$(scutil --dns |grep tun |awk {'print $NF'} |tr -d '()')
+    export TUNDEV=$(scutil --dns |grep if_index |grep tun |awk {'print $NF'} |tr -d '()')
     if [ -z "$TUNDEV" ]
     then
         print "Could not dynamically discover TUNDEV; defaulting to utun0"


### PR DESCRIPTION
Hey Matt,

I noticed that the Disconnect logic in vpn.sh has "utun0" hardcoded as the TUNDEV. For some reason, my system is using "tun0", so when I disconnect, name resolution requests are still directed to the tunnel device -- which at that point is disconnected, so those DNS lookups fail. I modified vpn.sh so it dynamically discovers TUNDEV via 'scutil --dns'.

Thanks,

- Sean