### PR TITLE
Disconnect function discovers TUNDEV via /tmp/tundev

### DIFF
--- a/vpn.sh
+++ b/vpn.sh
@@ -73,7 +73,7 @@ then
     export TUNDEV=$(scutil --dns |grep if_index |grep tun |awk {'print $NF'} |tr -d '()')
     if [ -z "$TUNDEV" ]
     then
-        print "Could not dynamically discover TUNDEV; defaulting to utun0"
+        echo "Could not dynamically discover TUNDEV; defaulting to utun0"
 	    export TUNDEV="utun0"
     fi
 	killall openconnect

--- a/vpn.sh
+++ b/vpn.sh
@@ -70,11 +70,11 @@ fi
 
 if [ "$COMMAND" == "D" ]
 then
-    export TUNDEV=$(scutil --dns |grep if_index |grep tun |awk {'print $NF'} |tr -d '()')
+    export TUNDEV=`cat /tmp/tundev`
     if [ -z "$TUNDEV" ]
     then
-        echo "Could not dynamically discover TUNDEV; defaulting to utun0"
-	    export TUNDEV="utun0"
+        echo "TUNDEV not found: DNS will likely be broken"
+        exit 1
     fi
 	killall openconnect
 	scutil >/dev/null 2>&1 <<-EOF

--- a/vpn.sh
+++ b/vpn.sh
@@ -70,7 +70,12 @@ fi
 
 if [ "$COMMAND" == "D" ]
 then
-	export TUNDEV="tun0"
+    export TUNDEV=$(scutil --dns |grep tun |awk {'print $NF'} |tr -d '()')
+    if [ -z "$TUNDEV" ]
+    then
+        print "Could not dynamically discover TUNDEV; defaulting to utun0"
+	    export TUNDEV="utun0"
+    fi
 	killall openconnect
 	scutil >/dev/null 2>&1 <<-EOF
 		open

--- a/vpn.sh
+++ b/vpn.sh
@@ -70,7 +70,7 @@ fi
 
 if [ "$COMMAND" == "D" ]
 then
-    export TUNDEV=$(scutil --dns |grep tun |awk {'print $NF'} |tr -d '()')
+    export TUNDEV=$(scutil --dns |grep if_index |grep tun |awk {'print $NF'} |tr -d '()')
     if [ -z "$TUNDEV" ]
     then
         print "Could not dynamically discover TUNDEV; defaulting to utun0"


### PR DESCRIPTION
This PR updates the vpn.sh disconnect function -- reading the TUNDEV from /tmp/tundev -- so graceful disconnects are possible in cases where a users' TUNDEV is something other than 'tun0'.