### PR TITLE
Allow connectivity to any VPN endpoint. Not just EMC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
-vpnsplit2
-=========
+# vpnsplit2
 
-
-Install Instructions:
----------
+## Install Instructions:
 
 0. Make sure you have the LATEST version of Anyconnect installed (currently 4.2), WITH the posture option!  You might need to google to find this :)
 1. Install the most recent XCode for your platform by running `xcode-select --install`.  They may already be installed, in which case continue with the next stop.  If you can't figure this out, ask for help from someone, it only gets harder from here.
 2. Install [homebrew](http://mxcl.github.com/homebrew/) with this command: `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 4. Use homebrew to install openconnect: `brew update && brew install openconnect`
 5. Get the latest wrapper scripts from my github: `cd ~ && git clone http://github.com/mcowger/vpnsplit2.git .vpn && cd .vpn &&  cd -`
-6. Everything is installed!
+6. Set right permissions to the script: `chmod +x ~/.vpn/vpn.sh`
+7. You are good to go!
 
-Usage
-----------
-To connect to the VPN:
->   sudo ~/.vpn/vpn.sh C NT-USERNAME [south|_west_|east] 
+## Usage
 
-* 'C' stands for connect, your username should be obvious.  
-* Select 'south', 'west', or 'east' to choose which endpoint you connect to.  
+#### To connect to the VPN:
+>   sudo ~/.vpn/vpn.sh C NT-USERNAME [VPN server]
+
+* `C` stands for connect
+* Your VPN username
+* Type the VPN server endpoint you want to connect to (e.g. `vpn-usa-west.mycompany.com`). Not needed if you have set the `VPNSERVER` environment variable.
 
 You'll get some output that looks like the following:
 
@@ -56,7 +55,8 @@ YOU ARE CONNECTED
 And the script will exit and you are connected, per the note above.  All standard resources are available via the VPN, but the tunnel is now a split include (meaning only certain address spaces are routed through the VPN, and all others around it).  Split-DNS is also enabled, meaning that the DNS server pushed by the VPN server is used only for the pushed domains, and all lookups happen against your standard DNS server.
 
 
-To disconnect
->sudo ./.vpn/vpn.sh D 
+#### To disconnect
+
+> sudo ~/.vpn/vpn.sh D
 
 The openconnect process will be killed and all your routes and DNS are put back.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # vpnsplit2
 
-## Install Instructions:
+## Install Instructions
 
 0. Make sure you have the LATEST version of Anyconnect installed (currently 4.2), WITH the posture option!  You might need to google to find this :)
 1. Install the most recent XCode for your platform by running `xcode-select --install`.  They may already be installed, in which case continue with the next stop.  If you can't figure this out, ask for help from someone, it only gets harder from here.
 2. Install [homebrew](http://mxcl.github.com/homebrew/) with this command: `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 4. Use homebrew to install openconnect: `brew update && brew install openconnect`
 5. Get the latest wrapper scripts from my github: `cd ~ && git clone http://github.com/mcowger/vpnsplit2.git .vpn && cd .vpn &&  cd -`
-6. Set write permissions to the script: `chmod +x ~/.vpn/vpn.sh`
+6. Set execute permissions to the script: `chmod +x ~/.vpn/vpn.sh`
 7. You are good to go!
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 2. Install [homebrew](http://mxcl.github.com/homebrew/) with this command: `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 4. Use homebrew to install openconnect: `brew update && brew install openconnect`
 5. Get the latest wrapper scripts from my github: `cd ~ && git clone http://github.com/mcowger/vpnsplit2.git .vpn && cd .vpn &&  cd -`
-6. Set right permissions to the script: `chmod +x ~/.vpn/vpn.sh`
+6. Set write permissions to the script: `chmod +x ~/.vpn/vpn.sh`
 7. You are good to go!
 
 ## Usage
 
-#### To connect to the VPN:
->   sudo ~/.vpn/vpn.sh C NT-USERNAME [VPN server]
+#### To connect to the VPN
+
+>   sudo ~/.vpn/vpn.sh C NT-USERNAME [VPN endpoint]
 
 * `C` stands for connect
 * Your VPN username

--- a/vpn.sh
+++ b/vpn.sh
@@ -1,7 +1,3 @@
-
-
-
-
 #!/bin/bash
 
 # echo "Checking for update"
@@ -26,98 +22,93 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 
-export COMMAND=$1
-export USERNAME=$2
-export LOCATION=$3
-export DIR=`dirname $0`
+COMMAND=$1
+USERNAME=$2
+LOCATION=$3
+DIR=`dirname $0`
 
 if [ -z "$COMMAND" ]
 then
-	echo "COMMAND not specified - (C)onnect or (D)isconnect"
-	exit 1
+  echo "COMMAND not specified - (C)onnect or (D)isconnect"
+  exit 1
 fi
 
-
-
-if [ -z "$LOCATION" ]
-then
-	export LOCATION="west"
-fi
 
 if [ "$COMMAND" == "C" ]
 then
-	if [ -z "$USERNAME" ]
-	then
-		echo "USERNAME not specified"
-		exit 1
-	fi
+  if [ -z "$USERNAME" ]
+  then
+    echo "USERNAME not specified"
+    exit 1
+  fi
 
-	echo "Checking for openconnect binary..."
-	if [ ! -e /usr/local/bin/openconnect ]
-	then
-		echo "openconnect binary not found, install it with homebrew (http://brew.sh)"
-		exit 1
-	fi
+  if [ -z "$LOCATION" ]
+  then
+    LOCATION=$VPNSERVER
+    if [ -z "$LOCATION" ]
+    then
+      echo "VPN endpoint not specified. Please set the VPNSERVER environment variable or pass the endpoint as an argument"
+      exit 1
+    fi
+  fi
+
+  echo "Checking for openconnect binary..."
+  if [ ! -e /usr/local/bin/openconnect ]
+  then
+    echo "openconnect binary not found, install it with homebrew (http://brew.sh)"
+    exit 1
+  fi
 
 
-	echo "Checking for cstub binary..."
-	if [ ! -e /opt/cisco/hostscan/bin/cstub ]
-	then
-		echo "cstub binary not found, get a full copy of the anyconnect installer and add the 'Posture' component..."
-		exit 1
-	fi
+  echo "Checking for cstub binary..."
+  if [ ! -e /opt/cisco/hostscan/bin/cstub ]
+  then
+    echo "cstub binary not found, get a full copy of the anyconnect installer and add the 'Posture' component..."
+    exit 1
+  fi
 
-	#echo "Updating Stats"
-	#curl -ss -o /dev/null -fG --data-urlencode sysversion="$(uname -v)" --data-urlencode user="$(echo $SUDO_USER)" --data-urlencode ip="$(curl -ss icanhazip.com)" --data-urlencode euid="$USERNAME)" --data-urlencode appname="vpnsplit2" http://collectappinfo.appspot.com &
-	echo "Running openconnect"
-	DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-	openconnect -u $USERNAME --background --timestamp --no-cert-check  vpn-usa-$LOCATION.emc.com --csd-wrapper $DIR/csdwrapper.sh --script=$DIR/vpnc-script
-	echo "Checking connection functionality"
-	sleep 1
-	ping -c 4 -i 1 -Q -t 1 -o 10.5.132.1
-	export RESULT=$?
-	if [ $RESULT == 0 ]
-	then
-		echo ""
-		echo "YOU ARE CONNECTED"
-	else
-		echo ""
-		echo "CONNECTION FAILED, CAN'T PING THROUGH TUNNEL.  RESULT:"
-		echo $RESULT
-	fi
-	exit 0
+  #echo "Updating Stats"
+  #curl -ss -o /dev/null -fG --data-urlencode sysversion="$(uname -v)" --data-urlencode user="$(echo $SUDO_USER)" --data-urlencode ip="$(curl -ss icanhazip.com)" --data-urlencode euid="$USERNAME)" --data-urlencode appname="vpnsplit2" http://collectappinfo.appspot.com &
+  echo "Running openconnect"
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  openconnect -u $USERNAME --background --timestamp --no-cert-check $LOCATION --csd-wrapper $DIR/csdwrapper.sh --script=$DIR/vpnc-script
+  echo "Checking connection functionality"
+  sleep 1
+  ping -c 4 -i 1 -Q -t 1 -o 10.5.132.1
+  export RESULT=$?
+  if [ $RESULT == 0 ]
+  then
+    echo ""
+    echo "YOU ARE CONNECTED"
+  else
+    echo ""
+    echo "CONNECTION FAILED, CAN'T PING THROUGH TUNNEL.  RESULT:"
+    echo $RESULT
+  fi
+  exit 0
 fi
 
 if [ "$COMMAND" == "D" ]
 then
-	export TUNDEV=`cat /tmp/tundev`
-	if [ -z "$TUNDEV" ]
-	then
-		echo "TUNDEV not found: DNS will likely be broken"
-		echo "Trying tun0 anyways"
-		export TUNDEV="tun0"
-	fi
-	killall openconnect
-	scutil >/dev/null 2>&1 <<-EOF
-		open
-		remove State:/Network/Service/$TUNDEV/IPv4
-		remove State:/Network/Service/$TUNDEV/DNS
-		close
-	EOF
-	echo "Briefly bouncing en0/en1 to clear cached DNS"
-	sudo ifconfig en0 down && sudo ifconfig en0 up
-	sudo ifconfig en1 down && sudo ifconfig en1 up
-	exit 0
+  export TUNDEV=`cat /tmp/tundev`
+  if [ -z "$TUNDEV" ]
+  then
+    echo "TUNDEV not found: DNS will likely be broken"
+    echo "Trying tun0 anyways"
+    export TUNDEV="tun0"
+  fi
+  killall openconnect
+  scutil >/dev/null 2>&1 <<-EOF
+    open
+    remove State:/Network/Service/$TUNDEV/IPv4
+    remove State:/Network/Service/$TUNDEV/DNS
+    close
+  EOF
+  echo "Briefly bouncing en0/en1 to clear cached DNS"
+  sudo ifconfig en0 down && sudo ifconfig en0 up
+  sudo ifconfig en1 down && sudo ifconfig en1 up
+  exit 0
 fi
 
 echo "Command not properly specified - (C) or (D).  Try again"
 exit 1
-
-
-
-
-
-
-
-
-

--- a/vpn.sh
+++ b/vpn.sh
@@ -17,8 +17,8 @@
 
 
 if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root or sudo " 1>&2
-   exit 1
+	 echo "This script must be run as root or sudo " 1>&2
+	 exit 1
 fi
 
 
@@ -29,85 +29,85 @@ DIR=`dirname $0`
 
 if [ -z "$COMMAND" ]
 then
-  echo "COMMAND not specified - (C)onnect or (D)isconnect"
-  exit 1
+	echo "COMMAND not specified - (C)onnect or (D)isconnect"
+	exit 1
 fi
 
 
 if [ "$COMMAND" == "C" ]
 then
-  if [ -z "$USERNAME" ]
-  then
-    echo "USERNAME not specified"
-    exit 1
-  fi
+	if [ -z "$USERNAME" ]
+	then
+		echo "USERNAME not specified"
+		exit 1
+	fi
 
-  if [ -z "$LOCATION" ]
-  then
-    LOCATION=$VPNSERVER
-    if [ -z "$LOCATION" ]
-    then
-      echo "VPN endpoint not specified. Please set the VPNSERVER environment variable or pass the endpoint as an argument"
-      exit 1
-    fi
-  fi
+	if [ -z "$LOCATION" ]
+	then
+		LOCATION=$VPNSERVER
+		if [ -z "$LOCATION" ]
+		then
+			echo "VPN endpoint not specified. Please set the VPNSERVER environment variable or pass the endpoint as an argument"
+			exit 1
+		fi
+	fi
 
-  echo "Checking for openconnect binary..."
-  if [ ! -e /usr/local/bin/openconnect ]
-  then
-    echo "openconnect binary not found, install it with homebrew (http://brew.sh)"
-    exit 1
-  fi
+	echo "Checking for openconnect binary..."
+	if [ ! -e /usr/local/bin/openconnect ]
+	then
+		echo "openconnect binary not found, install it with homebrew (http://brew.sh)"
+		exit 1
+	fi
 
 
-  echo "Checking for cstub binary..."
-  if [ ! -e /opt/cisco/hostscan/bin/cstub ]
-  then
-    echo "cstub binary not found, get a full copy of the anyconnect installer and add the 'Posture' component..."
-    exit 1
-  fi
+	echo "Checking for cstub binary..."
+	if [ ! -e /opt/cisco/hostscan/bin/cstub ]
+	then
+		echo "cstub binary not found, get a full copy of the anyconnect installer and add the 'Posture' component..."
+		exit 1
+	fi
 
-  #echo "Updating Stats"
-  #curl -ss -o /dev/null -fG --data-urlencode sysversion="$(uname -v)" --data-urlencode user="$(echo $SUDO_USER)" --data-urlencode ip="$(curl -ss icanhazip.com)" --data-urlencode euid="$USERNAME)" --data-urlencode appname="vpnsplit2" http://collectappinfo.appspot.com &
-  echo "Running openconnect"
-  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-  openconnect -u $USERNAME --background --timestamp --no-cert-check $LOCATION --csd-wrapper $DIR/csdwrapper.sh --script=$DIR/vpnc-script
-  echo "Checking connection functionality"
-  sleep 1
-  ping -c 4 -i 1 -Q -t 1 -o 10.5.132.1
-  export RESULT=$?
-  if [ $RESULT == 0 ]
-  then
-    echo ""
-    echo "YOU ARE CONNECTED"
-  else
-    echo ""
-    echo "CONNECTION FAILED, CAN'T PING THROUGH TUNNEL.  RESULT:"
-    echo $RESULT
-  fi
-  exit 0
+	#echo "Updating Stats"
+	#curl -ss -o /dev/null -fG --data-urlencode sysversion="$(uname -v)" --data-urlencode user="$(echo $SUDO_USER)" --data-urlencode ip="$(curl -ss icanhazip.com)" --data-urlencode euid="$USERNAME)" --data-urlencode appname="vpnsplit2" http://collectappinfo.appspot.com &
+	echo "Running openconnect"
+	DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+	openconnect -u $USERNAME --background --timestamp --no-cert-check $LOCATION --csd-wrapper $DIR/csdwrapper.sh --script=$DIR/vpnc-script
+	echo "Checking connection functionality"
+	sleep 1
+	ping -c 4 -i 1 -Q -t 1 -o 10.5.132.1
+	export RESULT=$?
+	if [ $RESULT == 0 ]
+	then
+		echo ""
+		echo "YOU ARE CONNECTED"
+	else
+		echo ""
+		echo "CONNECTION FAILED, CAN'T PING THROUGH TUNNEL.  RESULT:"
+		echo $RESULT
+	fi
+	exit 0
 fi
 
 if [ "$COMMAND" == "D" ]
 then
-  export TUNDEV=`cat /tmp/tundev`
-  if [ -z "$TUNDEV" ]
-  then
-    echo "TUNDEV not found: DNS will likely be broken"
-    echo "Trying tun0 anyways"
-    export TUNDEV="tun0"
-  fi
-  killall openconnect
-  scutil >/dev/null 2>&1 <<-EOF
-    open
-    remove State:/Network/Service/$TUNDEV/IPv4
-    remove State:/Network/Service/$TUNDEV/DNS
-    close
-  EOF
-  echo "Briefly bouncing en0/en1 to clear cached DNS"
-  sudo ifconfig en0 down && sudo ifconfig en0 up
-  sudo ifconfig en1 down && sudo ifconfig en1 up
-  exit 0
+	export TUNDEV=`cat /tmp/tundev`
+	if [ -z "$TUNDEV" ]
+	then
+		echo "TUNDEV not found: DNS will likely be broken"
+		echo "Trying tun0 anyways"
+		export TUNDEV="tun0"
+	fi
+	killall openconnect
+	scutil >/dev/null 2>&1 <<-EOF
+		open
+		remove State:/Network/Service/$TUNDEV/IPv4
+		remove State:/Network/Service/$TUNDEV/DNS
+		close
+	EOF
+	echo "Briefly bouncing en0/en1 to clear cached DNS"
+	sudo ifconfig en0 down && sudo ifconfig en0 up
+	sudo ifconfig en1 down && sudo ifconfig en1 up
+	exit 0
 fi
 
 echo "Command not properly specified - (C) or (D).  Try again"


### PR DESCRIPTION
Hi @mcowger , 

First off, thank you for this awesome script, it's been very useful to me.

Basically, this PR includes the possibility to connect to any VPN server endpoint. Not just the EMC VPN servers as it was hardcoded before. 

As you now have to specify the full VPN server endpoint (e.g. `vpn-usa-west.emc.com`) and not just the region (e.g. `west`), I have added the possibility to read the endpoint from an environment variable (i.e. `VPNSERVER`). This way you don't have to type it every time you call the script.

I have also updated the README file accordingly. 

Please let me know what you think.

Thanks!